### PR TITLE
fix(config): resolve typescript process error

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,9 +6,13 @@
         "module": "ESNext",
         "moduleResolution": "bundler",
         "allowSyntheticDefaultImports": true,
-        "strict": false
+        "strict": false,
+        "types": [
+            "node"
+        ]
     },
     "include": [
-        "vite.config.ts"
+        "vite.config.ts",
+        "playwright.config.ts"
     ]
 }


### PR DESCRIPTION
Closes #24.

Added playwright.config.ts to tsconfig.node.json and explicitly enabled 'node' types to fix lint errors.